### PR TITLE
dmenu functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,14 @@ arguments:
   -u	Show name under icon
   -b	Show scroll bars
   -n	Max name length
-  -p	Items per row
+  -p	Set placeholder text
+  -P	Items per row
   -a	Anchors ("top right bottom left")
   -W	Set window width
   -H	Set window Height
-  -l	Disable use of layer shell
+  -L	Disable use of layer shell
   -v	Prints version info
+  -d	dmenu emulation
   -D	Set dock items ("Terminal,FileManager,WebBrowser,ect..")
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ arguments:
   -s	Hide the search bar
   -i	Set launcher icon size
   -I	Set dock icon size
-  -m	Set launcher margins
+  -M	Set launcher margins
   -u	Show name under icon
   -b	Show scroll bars
   -n	Max name length

--- a/config.conf
+++ b/config.conf
@@ -15,3 +15,4 @@ monitor=0
 layer-shell=true
 dock-items=
 animation-duration=250
+prompt=Search

--- a/src/dmenuentry.hpp
+++ b/src/dmenuentry.hpp
@@ -1,0 +1,11 @@
+#ifndef DMENUENTRY
+#define DMENUENTRY
+
+class dmenuentry {
+	public:
+		Glib::ustring content;
+		Glib::ustring icon;
+		void unreference(){}
+};
+
+#endif

--- a/src/launcher.cpp
+++ b/src/launcher.cpp
@@ -42,6 +42,53 @@ launcher::launcher(const std::map<std::string, std::map<std::string, std::string
 	set_tooltip_text(descr);
 }
 
+launcher::launcher(const std::map<std::string, std::map<std::string, std::string>>& cfg, const Glib::RefPtr<dmenuentry> &entry) : Gtk::Box(), config_main(cfg) {
+	name = entry->content;
+	long_name = entry->content;
+	progr = entry->content;
+	descr = entry->content;
+	app_info = NULL;
+
+	if (config_main["main"]["items-per-row"] == "1")
+		set_margin_top(std::stoi(config_main["main"]["app-margins"]));
+	else
+		set_margin(std::stoi(config_main["main"]["app-margins"]));
+
+	image_program.set_from_icon_name(entry->icon);
+	image_program.set_pixel_size(std::stoi(config_main["main"]["icon-size"]));
+
+	if (long_name.length() > std::stoul(config_main["main"]["name-length"]))
+		label_program.set_text(long_name.substr(0, std::stoi(config_main["main"]["name-length"]) - 2) + "..");
+	else
+		label_program.set_text(long_name);
+
+	int size_request = -1;
+	if (config_main["main"]["name-under-icon"] == "true") {
+		set_orientation(Gtk::Orientation::VERTICAL);
+		size_request = std::stoi(config_main["main"]["name-length"]) * 10;
+		image_program.set_vexpand(true);
+		image_program.set_valign(Gtk::Align::END);
+		label_program.set_margin_top(3);
+		label_program.set_vexpand(true);
+		label_program.set_valign(Gtk::Align::START);
+	}
+	else
+		label_program.property_margin_start().set_value(10);
+
+	append(image_program);
+	append(label_program);
+
+	set_hexpand(true);
+	set_size_request(size_request, size_request);
+
+	get_style_context()->add_class("launcher");
+	set_tooltip_text(descr);
+}
+
+Glib::ustring launcher::get_long_name(){
+	return long_name;
+}
+
 bool launcher::matches(Glib::ustring pattern) {
 	Glib::ustring text =
 		name.lowercase() + "$" +
@@ -53,6 +100,6 @@ bool launcher::matches(Glib::ustring pattern) {
 }
 
 bool launcher::operator < (const launcher& other) {
-	return Glib::ustring(app_info->get_name()).lowercase()
-		< Glib::ustring(other.app_info->get_name()).lowercase();
+	return Glib::ustring(long_name).lowercase()
+		< Glib::ustring(other.long_name).lowercase();
 }

--- a/src/launcher.cpp
+++ b/src/launcher.cpp
@@ -1,4 +1,5 @@
 #include "launcher.hpp"
+#include <filesystem>
 
 launcher::launcher(const std::map<std::string, std::map<std::string, std::string>>& cfg, const Glib::RefPtr<Gio::AppInfo> &app) : Gtk::Box(), app_info(app), config_main(cfg) {
 	name = app_info->get_name();
@@ -54,7 +55,16 @@ launcher::launcher(const std::map<std::string, std::map<std::string, std::string
 	else
 		set_margin(std::stoi(config_main["main"]["app-margins"]));
 
-	image_program.set_from_icon_name(entry->icon);
+	if (entry->icon[0] == '~') {
+		
+	}
+
+	std::filesystem::path iconpath = std::filesystem::path(entry->icon);
+	if (std::filesystem::exists(iconpath) ) {
+		image_program.set(std::filesystem::absolute(iconpath));
+	} else {
+		image_program.set_from_icon_name(entry->icon);
+	}
 	image_program.set_pixel_size(std::stoi(config_main["main"]["icon-size"]));
 
 	if (long_name.length() > std::stoul(config_main["main"]["name-length"]))

--- a/src/launcher.hpp
+++ b/src/launcher.hpp
@@ -5,22 +5,25 @@
 #include <giomm/desktopappinfo.h>
 
 #include "config.hpp"
+#include "dmenuentry.hpp"
 
 class launcher : public Gtk::Box {
 	public:
 		launcher(const std::map<std::string, std::map<std::string, std::string>>& cfg, const Glib::RefPtr<Gio::AppInfo> &app);
+		launcher(const std::map<std::string, std::map<std::string, std::string>>& cfg, const Glib::RefPtr<dmenuentry> &entry);
 		Glib::RefPtr<Gio::AppInfo> app_info;
 
 		bool matches(Glib::ustring text);
 		bool operator < (const launcher& other);
+		Glib::ustring get_long_name();
 
 	private:
 		std::map<std::string, std::map<std::string, std::string>> config_main;
+		Glib::ustring long_name;
 		Gtk::Image image_program;
 		Gtk::Label label_program;
 
 		Glib::ustring name;
-		Glib::ustring long_name;
 		Glib::ustring progr;
 		Glib::ustring descr;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -130,6 +130,11 @@ int main(int argc, char* argv[]) {
 				config["main"]["monitor"] = optarg;
 				continue;
 
+			// -l sets the number of lines in dmenu scripts
+			// there is no trivial way to implement it, but ignoring it is an option
+			case 'l':
+				break;
+
 			case 'L':
 				config["main"]["layer-shell"] = "false";
 				continue;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -162,12 +162,14 @@ int main(int argc, char* argv[]) {
 				std::cout << "  -u	Show name under icon" << std::endl;
 				std::cout << "  -b	Show scroll bars" << std::endl;
 				std::cout << "  -n	Max name length" << std::endl;
-				std::cout << "  -p	Items per row" << std::endl;
+				std::cout << "  -p	Set placeholder text" << std::endl;
+				std::cout << "  -P	Items per row" << std::endl;
 				std::cout << "  -a	Set anchors" << std::endl;
 				std::cout << "  -W	Set window width" << std::endl;
 				std::cout << "  -H	Set window Height" << std::endl;
 				std::cout << "  -M	Set primary monitor" << std::endl;
-				std::cout << "  -l	Disable use of layer shell" << std::endl;
+				std::cout << "  -L	Disable use of layer shell" << std::endl;
+				std::cout << "  -d	dmenu emulation" << std::endl;
 				std::cout << "  -D	Set dock items" << std::endl;
 				std::cout << "  -v	Prints version info" << std::endl;
 				std::cout << "  -h	Show this help message" << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,7 +73,7 @@ int main(int argc, char* argv[]) {
 	// Read launch arguments
 	#ifdef CONFIG_RUNTIME
 	while (true) {
-		switch(getopt(argc, argv, "Ssi:I:m:ubn:p:a:W:H:M:lD:vh")) {
+		switch(getopt(argc, argv, "Ssi:I:m:ubn:p:a:W:H:M:l:D:vhLP:d")) {
 			case 'S':
 				config["main"]["start-hidden"] = "true";
 				continue;
@@ -106,8 +106,12 @@ int main(int argc, char* argv[]) {
 				config["main"]["name-length"] = optarg;
 				continue;
 
-			case 'p':
+			case 'P':
 				config["main"]["items-per-row"] = optarg;
+				continue;
+
+			case 'p':
+				config["main"]["prompt"] = optarg;
 				continue;
 
 			case 'a':
@@ -126,7 +130,7 @@ int main(int argc, char* argv[]) {
 				config["main"]["monitor"] = optarg;
 				continue;
 
-			case 'l':
+			case 'L':
 				config["main"]["layer-shell"] = "false";
 				continue;
 
@@ -134,6 +138,10 @@ int main(int argc, char* argv[]) {
 				config["main"]["dock-items"] = optarg;
 				config["main"]["layer-shell"] = "true";
 				config["main"]["anchors"] = "top right bottom left";
+				continue;
+
+			case 'd':
+				config["main"]["dmenu"] = "true";
 				continue;
 
 			case 'v':
@@ -171,6 +179,10 @@ int main(int argc, char* argv[]) {
 
 			break;
 	}
+
+	if ( config["main"]["dmenu"] == "true" ) {
+		config["main"]["start-hidden"] = "false";
+	}
 	#endif
 
 	Glib::RefPtr<Gtk::Application> app = Gtk::Application::create("funky.sys64.sysmenu");
@@ -179,10 +191,12 @@ int main(int argc, char* argv[]) {
 	load_libsysmenu();
 	win = sysmenu_create_ptr(config);
 
-	// Catch signals
-	signal(SIGUSR1, handle_signal);
-	signal(SIGUSR2, handle_signal);
-	signal(SIGRTMIN, handle_signal);
+	// Catch signals if not in dmenu mode
+	if (config["main"]["dmenu"] != "true") {
+		signal(SIGUSR1, handle_signal);
+		signal(SIGUSR2, handle_signal);
+		signal(SIGRTMIN, handle_signal);
+	}
 
 	return app->run();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,31 @@ void handle_signal(int signum) {
 	sysmenu_handle_signal_ptr(win, signum);
 }
 
+void usage() {
+	std::cout << "usage:" << std::endl;
+	std::cout << "  sysmenu [argument...]:\n" << std::endl;
+	std::cout << "arguments:" << std::endl;
+	std::cout << "  -S	Hide the program on launch" << std::endl;
+	std::cout << "  -s	Hide the search bar" << std::endl;
+	std::cout << "  -i	Set launcher icon size" << std::endl;
+	std::cout << "  -I	Set dock icon size" << std::endl;
+	std::cout << "  -M	Set launcher margins" << std::endl;
+	std::cout << "  -u	Show name under icon" << std::endl;
+	std::cout << "  -b	Show scroll bars" << std::endl;
+	std::cout << "  -n	Max name length" << std::endl;
+	std::cout << "  -p	Set placeholder text" << std::endl;
+	std::cout << "  -P	Items per row" << std::endl;
+	std::cout << "  -a	Set anchors" << std::endl;
+	std::cout << "  -W	Set window width" << std::endl;
+	std::cout << "  -H	Set window Height" << std::endl;
+	std::cout << "  -m	Set primary monitor" << std::endl;
+	std::cout << "  -L	Disable use of layer shell" << std::endl;
+	std::cout << "  -d	dmenu emulation" << std::endl;
+	std::cout << "  -D	Set dock items" << std::endl;
+	std::cout << "  -v	Prints version info" << std::endl;
+	std::cout << "  -h	Show this help message" << std::endl;
+}
+
 void load_libsysmenu() {
 	void* handle = dlopen("libsysmenu.so", RTLD_LAZY);
 	if (!handle) {
@@ -72,8 +97,9 @@ int main(int argc, char* argv[]) {
 
 	// Read launch arguments
 	#ifdef CONFIG_RUNTIME
+	bool dmenuarg=false;
 	while (true) {
-		switch(getopt(argc, argv, "Ssi:I:m:ubn:p:a:W:H:M:l:D:vhLP:d")) {
+		switch(getopt(argc, argv, "Ssi:I:m:ubn:p:a:W:H:M:l:D:vhLP:dw:")) {
 			case 'S':
 				config["main"]["start-hidden"] = "true";
 				continue;
@@ -90,7 +116,7 @@ int main(int argc, char* argv[]) {
 				config["main"]["dock-icon-size"] = optarg;
 				continue;
 
-			case 'm':
+			case 'M':
 				config["main"]["app-margin"] = optarg;
 				continue;
 
@@ -126,13 +152,15 @@ int main(int argc, char* argv[]) {
 				config["main"]["height"] = optarg;
 				continue;
 
-			case 'M':
+			case 'm':
 				config["main"]["monitor"] = optarg;
 				continue;
 
 			// -l sets the number of lines in dmenu scripts
 			// there is no trivial way to implement it, but ignoring it is an option
 			case 'l':
+			case 'w':
+				dmenuarg=true;
 				break;
 
 			case 'L':
@@ -156,28 +184,7 @@ int main(int argc, char* argv[]) {
 
 			case 'h':
 			default :
-				std::cout << "usage:" << std::endl;
-				std::cout << "  sysmenu [argument...]:\n" << std::endl;
-				std::cout << "arguments:" << std::endl;
-				std::cout << "  -S	Hide the program on launch" << std::endl;
-				std::cout << "  -s	Hide the search bar" << std::endl;
-				std::cout << "  -i	Set launcher icon size" << std::endl;
-				std::cout << "  -I	Set dock icon size" << std::endl;
-				std::cout << "  -m	Set launcher margins" << std::endl;
-				std::cout << "  -u	Show name under icon" << std::endl;
-				std::cout << "  -b	Show scroll bars" << std::endl;
-				std::cout << "  -n	Max name length" << std::endl;
-				std::cout << "  -p	Set placeholder text" << std::endl;
-				std::cout << "  -P	Items per row" << std::endl;
-				std::cout << "  -a	Set anchors" << std::endl;
-				std::cout << "  -W	Set window width" << std::endl;
-				std::cout << "  -H	Set window Height" << std::endl;
-				std::cout << "  -M	Set primary monitor" << std::endl;
-				std::cout << "  -L	Disable use of layer shell" << std::endl;
-				std::cout << "  -d	dmenu emulation" << std::endl;
-				std::cout << "  -D	Set dock items" << std::endl;
-				std::cout << "  -v	Prints version info" << std::endl;
-				std::cout << "  -h	Show this help message" << std::endl;
+				usage();
 				return 0;
 
 			case -1:
@@ -189,6 +196,9 @@ int main(int argc, char* argv[]) {
 
 	if ( config["main"]["dmenu"] == "true" ) {
 		config["main"]["start-hidden"] = "false";
+	} else if ( dmenuarg ) {
+		usage();
+		return 0;
 	}
 	#endif
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -233,9 +233,12 @@ void sysmenu::on_search_changed() {
 bool sysmenu::on_key_press(const guint &keyval, const guint &keycode, const Gdk::ModifierType &state) {
 	switch(keyval){
 		case GDK_KEY_Return:
-			if ( matches > 0 && state == Gdk::ModifierType::SHIFT_MASK && config_main["main"]["dmenu"] == "true"){
+			if ( matches > 0 && state == Gdk::ModifierType::CONTROL_MASK && config_main["main"]["dmenu"] == "true"){
 				launcher *item = dynamic_cast<launcher*>(selected_child->get_child());
 				std::cout << item->get_long_name() << std::endl;
+			} else if (state == Gdk::ModifierType::SHIFT_MASK && config_main["main"]["dmenu"] == "true") {
+				std::cout << entry_search.get_text() << std::endl;
+				exit(0);
 			}
 			break;
 		case GDK_KEY_Escape:

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -401,7 +401,7 @@ void sysmenu::handle_signal(const int &signum) {
 				break;
 			case 12: // Hiding window
 				if ( config_main["main"]["dmenu"] == "true"){
-					exit(0);
+					exit(1);
 				}
 				get_style_context()->remove_class("visible");
 				if (config_main["main"]["dock-items"] != "") {

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -56,7 +56,9 @@ class sysmenu : public Gtk::Window {
 		bool on_sort(Gtk::FlowBoxChild*, Gtk::FlowBoxChild*);
 
 		void app_info_changed(GAppInfoMonitor* gappinfomonitor);
+		void load_dmenu_items();
 		void load_menu_item(const Glib::RefPtr<Gio::AppInfo> &app_info);
+		void load_menu_item(Glib::ustring string);
 		void run_menu_item(Gtk::FlowBoxChild* child, const bool &recent);
 
 		void on_drag_start(const double &x, const double &y);


### PR DESCRIPTION
This PR allows sysmenu to work as a drop-in replacement for dmenu, with only some limitations in CLI compatibility.

The basic functionality functionality of dmenu is very simple: it takes a newline-separated list, spawns a UI to let the user select one of them, prints it to stdout and returns.

This PR implements it, as well as some more:
- Confirm selection: print itme to stdout but don't return
- Confirm input: print the search string to stdout and return
- Rofi-style icon selection: an icon for an entry can be set by appending `\0\x1ficon\x1fname_or_path` to the input string

Some misc behavior also changes while run with `-d`:
- Disabled signal handing
- The window is never hiddden
- Pressing Escape causes the program to fail (same as dmenu)