### PR TITLE
Fix "Failed to initialize layer surface, GTK4 Layer Shell may have been linked after libwayland

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LIBDIR ?= $(PREFIX)/lib
 DATADIR ?= $(PREFIX)/share
 
 CXXFLAGS += -Oz -s -Wall -flto -fno-exceptions -fPIC
-LDFLAGS += -Wl,--as-needed,-z,now,-z,pack-relative-relocs
+LDFLAGS += -Wl,--no-as-needed,-z,now,-z,pack-relative-relocs
 
 CXXFLAGS += $(shell pkg-config --cflags $(PKGS))
 LDFLAGS += $(shell pkg-config --libs $(PKGS))
@@ -41,7 +41,7 @@ $(BINS): src/git_info.hpp src/main.cpp src/config_parser.o
 	src/main.cpp \
 	src/config_parser.o \
 	$(CXXFLAGS) \
-	$(shell pkg-config --libs gtkmm-4.0 gtk4-layer-shell-0)
+	$(LDFLAGS) -lwayland-client
 
 $(LIBS): $(OBJS)
 	$(call progress, Linking $@)


### PR DESCRIPTION
by modelling the Makefile after sysshell's makefile, which doesn't have this problem.

The error message states

> Move gtk4-layer-shell before libwayland-client in the linker options.
> See https://github.com/wmww/gtk4-layer-shell/blob/main/linking.md for more info

But I also needed to add `--no-as-needed flag` to LDFLAGS